### PR TITLE
feat: Add subscription status display and API endpoint

### DIFF
--- a/src/components/SubscriptionStatus.astro
+++ b/src/components/SubscriptionStatus.astro
@@ -1,0 +1,66 @@
+<div
+  id="subscription-status-container"
+  class="p-4 border border-gray-200 rounded-lg bg-gray-50 text-gray-800"
+>
+  <h3 class="font-bold text-lg mb-2">Subscription Status</h3>
+  <div id="status-content">
+    <p>Loading...</p>
+  </div>
+</div>
+
+<script>
+  import { supabase } from "../lib/supabase";
+
+  document.addEventListener("DOMContentLoaded", async () => {
+    const statusContainer = document.getElementById("status-content");
+    if (!statusContainer) return;
+
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    if (!session?.access_token) {
+      statusContainer.innerHTML = `<p>Please log in to check your subscription.</p>`;
+      return;
+    }
+
+    try {
+      const response = await fetch("/api/subscription", {
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+        },
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "Could not retrieve status.");
+      }
+
+      if (data.isSubscribed) {
+        const tier =
+          data.subscription.tier === "prime"
+            ? "Twitch Prime"
+            : `Tier ${parseInt(data.subscription.tier) / 1000}`;
+
+        statusContainer.innerHTML = `
+          <p class="text-green-600 font-semibold">
+            ✅ You are subscribed!
+          </p>
+          <p class="mt-1">
+            Current Tier: <strong>${tier}</strong>
+          </p>
+        `;
+      } else {
+        statusContainer.innerHTML = `
+          <p class="text-red-600 font-semibold">
+            ❌ You are not subscribed.
+          </p>
+        `;
+      }
+    } catch (error) {
+      if (error instanceof Error)
+        statusContainer.innerHTML = `<p>Error: ${error.message}</p>`;
+    }
+  });
+</script>

--- a/src/pages/api/subscription.ts
+++ b/src/pages/api/subscription.ts
@@ -1,0 +1,104 @@
+import { supabase } from "@lib/supabase";
+import type { APIRoute } from "astro";
+const twitchClientId = import.meta.env.TWITCH_CLIENT_ID;
+const twitchClientSecret = import.meta.env.TWITCH_CLIENT_SECRET;
+const broadcasterId = import.meta.env.TWITCH_BROADCASTER_ID;
+
+async function getTwitchAppAccessToken() {
+  const tokenUrl = `https://id.twitch.tv/oauth2/token?client_id=${twitchClientId}&client_secret=${twitchClientSecret}&grant_type=client_credentials`;
+
+  try {
+    const response = await fetch(tokenUrl, { method: "POST" });
+    const data = await response.json();
+    return data.access_token;
+  } catch (error) {
+    console.error("Failed to get Twitch App Access Token:", error);
+    return null;
+  }
+}
+
+export const GET: APIRoute = async ({ request }) => {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const token = authHeader.split(" ")[1];
+  const { data: userData, error: userError } =
+    await supabase.auth.getUser(token);
+
+  if (userError || !userData.user) {
+    return new Response(
+      JSON.stringify({ error: "Invalid token or user not found" }),
+      {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  const twitchUserId = userData.user.user_metadata?.provider_id;
+  if (!twitchUserId) {
+    return new Response(
+      JSON.stringify({ error: "Twitch user ID not found in user metadata" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const appAccessToken = await getTwitchAppAccessToken();
+  if (!appAccessToken) {
+    return new Response(
+      JSON.stringify({ error: "Could not retrieve Twitch API token" }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const subscriptionCheckUrl = `https://api.twitch.tv/helix/subscriptions/user?broadcaster_id=${broadcasterId}&user_id=${twitchUserId}`;
+
+  try {
+    const twitchResponse = await fetch(subscriptionCheckUrl, {
+      headers: {
+        "Client-ID": twitchClientId,
+        Authorization: `Bearer ${appAccessToken}`,
+      },
+    });
+
+    if (twitchResponse.status === 200) {
+      const subscriptionData = await twitchResponse.json();
+      return new Response(
+        JSON.stringify({
+          isSubscribed: true,
+          subscription: subscriptionData.data[0],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    if (twitchResponse.status === 404) {
+      return new Response(
+        JSON.stringify({ isSubscribed: false, subscription: null }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const errorBody = await twitchResponse.text();
+    return new Response(
+      JSON.stringify({
+        error: "Failed to check subscription",
+        details: errorBody,
+      }),
+      {
+        status: twitchResponse.status,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: "An unexpected error occurred" }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import SubscriptionStatus from "@/components/SubscriptionStatus.astro";
 import CTA from "../components/CTA.astro";
 import Footer from "../components/Footer.astro";
 import FrequentQuestions from "../components/FrequentQuestions.astro";
@@ -21,6 +22,7 @@ import Layout from "../layouts/Layout.astro";
     <TicketAtropo />
     <FrequentQuestions />
     <CTA />
+    <SubscriptionStatus />
     <Footer />
   </main>
 </Layout>


### PR DESCRIPTION
This commit introduces a new feature to display the user's subscription status and fetches this information from a new API endpoint. The `SubscriptionStatus.astro` component handles the UI, while `api/subscription.ts` manages the logic for checking Twitch subscriptions using user authentication tokens and the Twitch API. The homepage `index.astro` is updated to include the new `SubscriptionStatus` component.

<img width="308" height="167" alt="image" src="https://github.com/user-attachments/assets/270bd8ca-1cb7-4f30-94a1-6efd30346c5a" />
