### PR TITLE
fix(countdown): hide view transition when dialog is open

### DIFF
--- a/src/styles/countdown.css
+++ b/src/styles/countdown.css
@@ -62,3 +62,7 @@ html {
 ::view-transition {
   pointer-events: none;
 }
+
+:has(dialog[open])::view-transition {
+  display: none;
+}


### PR DESCRIPTION
Este pull request añade una corrección menor de CSS para mejorar el manejo de las view transitions cuando el dialog está abierto, lo que provocaba que los números estuvieran sobre el elemento.

* Actualización de estilos: Oculta `::view-transition` cuando cualquier elemento dialog está abierto utilizando el selector `:has(dialog[open])` en `countdown.css`.

### Vista previa

<table>
<tbody>
<tr>
<th>
Antes
</th>
<th>
Después
</th>
</tr>
<tr>
<td valign="top">
<video src="https://github.com/user-attachments/assets/ba6811cc-462a-4e00-94a9-11e6711253f8"></video>
</td>
<td>
<video src="https://github.com/user-attachments/assets/33bd7e77-c26a-422b-b9b4-bb6c6352aefa"></video>
</td>
</tr>
</tbody>
</table>
