### PR TITLE
feat: enhance countdown functionality with start/stop controls and oberver for style changes (#38)

### DIFF
--- a/src/components/Countdown.astro
+++ b/src/components/Countdown.astro
@@ -49,6 +49,7 @@ const units: Unit[] = [
   type UnitKey = "day" | "hour" | "minute" | "second";
   type CountdownValues = Record<UnitKey, number>;
 
+  let intervalId: ReturnType<typeof setInterval> | null = null;
   const COUNTDOWN_FROM = new Date("2025-10-03T20:00:00").getTime();
   const TIME_UNITS = {
     SECOND: 1000,
@@ -116,6 +117,37 @@ const units: Unit[] = [
     }
   }
 
-  updateCountdown();
-  setInterval(updateCountdown, 1000);
+  function startCountdown() {
+    if (intervalId === null) {
+      updateCountdown();
+      intervalId = setInterval(updateCountdown, 1000);
+    }
+  }
+
+  function stopCountdown() {
+    if (intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  }
+
+  startCountdown();
+
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (
+        mutation.type === "attributes" &&
+        mutation.attributeName === "style"
+      ) {
+        const hasStyle = document.body.hasAttribute("style");
+        if (hasStyle) {
+          stopCountdown();
+        } else {
+          startCountdown();
+        }
+      }
+    });
+  });
+
+  observer.observe(document.body, { attributes: true, attributeFilter: ["style"] });
 </script>

--- a/src/components/ShareTicket.astro
+++ b/src/components/ShareTicket.astro
@@ -275,7 +275,7 @@ const {
 
       function closeModal() {
         $modalOverlay?.classList.remove("show");
-        document.body.style.overflow = "auto";
+        document.body.removeAttribute("style");
       }
 
       async function copyToClipboard(text: string) {


### PR DESCRIPTION
Este pull request soluciona #38 y actualiza la lógica del contador y el modal para asegurar una correcta interacción entre componentes de la interfaz. El cambio más importantes es añadir la gestión de intervalos para el temporizador del contador y el uso de un `MutationObserver` para pausar o reanudar el contador según los cambios en el atributo de estilo del body.

### Mejoras al contador:

* Se agregó la variable `intervalId` y las funciones `startCountdown`/`stopCountdown` para gestionar el intervalo del temporizador, evitando que se ejecuten múltiples intervalos simultáneamente. [[1]](diffhunk://#diff-97bc26232db60866c25dc182e687f8ab2db4acba1b2afd204816fe1e96796700R52) [[2]](diffhunk://#diff-97bc26232db60866c25dc182e687f8ab2db4acba1b2afd204816fe1e96796700R120-R152)
* Se implementó un `MutationObserver` que monitorea los cambios en el atributo `style` del body; el temporizador del contador se pausa cuando el estilo está presente y se reanuda cuando se elimina, permitiendo una mejor coordinación con el modal.

### Actualización del modal:

* Se cambió la lógica de cierre del modal para eliminar el atributo `style` del body en lugar de establecer `overflow` en `"auto"`, asegurando coherencia con el observador del contador.

### Vista previa:

https://github.com/user-attachments/assets/cb8243b1-690c-4f7c-87a1-962d85975516
