### PR TITLE
feat: Add live indicator and Twitch API integration

### DIFF
--- a/src/components/LiveIndicator.astro
+++ b/src/components/LiveIndicator.astro
@@ -1,0 +1,55 @@
+---
+interface Props {
+  channelName: string;
+}
+
+const { channelName } = Astro.props;
+---
+
+<a
+  id="floating-live-indicator"
+  href={`https://twitch.tv/${channelName}`}
+  target="_blank"
+  rel="noopener noreferrer"
+  title={`¡${channelName} está en directo! Haz clic para unirte.`}
+  class="fixed bottom-6 right-6 z-50
+    inline-flex items-center gap-3
+    py-2 px-4
+    bg-rose-600 text-white
+    font-bold text-sm rounded-full
+    shadow-lg
+    transform transition-transform hover:scale-105"
+>
+  <span class="relative flex h-3 w-3">
+    <span
+      class="animate-ping absolute inline-flex h-full w-full rounded-full bg-white opacity-75"
+    ></span>
+    <span class="relative inline-flex rounded-full h-3 w-3 bg-white"></span>
+  </span>
+
+  <span>EN VIVO</span>
+</a>
+
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    const indicator = document.getElementById("floating-live-indicator");
+    if (!indicator) return;
+
+    const checkLiveStatus = async () => {
+      try {
+        const response = await fetch("/api/is-live");
+        if (!response.ok) return;
+
+        const data = await response.json();
+
+        if (data.isLive) {
+          indicator.classList.remove("hidden");
+        }
+      } catch (error) {
+        console.error("Error fetching Twitch live status:", error);
+      }
+    };
+
+    checkLiveStatus();
+  });
+</script>

--- a/src/pages/api/is-live.ts
+++ b/src/pages/api/is-live.ts
@@ -1,0 +1,95 @@
+// src/pages/api/is-live.ts
+import type { APIRoute } from "astro";
+
+const CLIENT_ID = import.meta.env.TWITCH_CLIENT_ID;
+const CLIENT_SECRET = import.meta.env.TWITCH_CLIENT_SECRET;
+const BROADCASTER_ID = import.meta.env.TWITCH_BROADCASTER_ID;
+
+async function getAppAccessToken() {
+  const response = await fetch("https://id.twitch.tv/oauth2/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: `client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&grant_type=client_credentials`,
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to get Twitch access token");
+  }
+
+  const data = await response.json();
+  return data.access_token;
+}
+
+export const GET: APIRoute = async () => {
+  if (!CLIENT_ID || !CLIENT_SECRET || !BROADCASTER_ID) {
+    return new Response(
+      JSON.stringify({
+        error: "Twitch API credentials or Broadcaster ID are not configured.",
+      }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+
+  try {
+    const accessToken = await getAppAccessToken();
+
+    const response = await fetch(
+      `https://api.twitch.tv/helix/streams?user_id=${BROADCASTER_ID}`,
+      {
+        headers: {
+          "Client-ID": CLIENT_ID,
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Twitch API responded with status ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    const isLive = data.data && data.data.length > 0;
+    console.log({ isLive, data: data.data });
+
+    const streamData = isLive
+      ? {
+          title: data.data[0].title,
+          game_name: data.data[0].game_name,
+          viewer_count: data.data[0].viewer_count,
+          started_at: data.data[0].started_at,
+          user_name: data.data[0].user_name,
+        }
+      : null;
+
+    return new Response(
+      JSON.stringify({
+        isLive: isLive,
+        channelId: BROADCASTER_ID,
+        streamData: streamData,
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control":
+            "public, max-age=60, s-maxage=60, stale-while-revalidate=120",
+        },
+      }
+    );
+  } catch (error) {
+    console.error(error);
+    return new Response(
+      JSON.stringify({ error: "Failed to fetch stream status." }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import SubscriptionStatus from "@/components/SubscriptionStatus.astro";
+import LiveIndicator from "@/components/LiveIndicator.astro";
 import CTA from "../components/CTA.astro";
 import Footer from "../components/Footer.astro";
 import FrequentQuestions from "../components/FrequentQuestions.astro";
@@ -24,5 +24,5 @@ import Layout from "../layouts/Layout.astro";
     <CTA />
     <Footer />
   </main>
+  <LiveIndicator channelName="afor_digital" />
 </Layout>
-


### PR DESCRIPTION
Introduces a floating live indicator component that checks the Twitch stream status via a new API endpoint. The indicator displays if a channel is live and provides a link to the Twitch channel. The API endpoint fetches stream data using Twitch API credentials.
<img width="1271" height="953" alt="image" src="https://github.com/user-attachments/assets/cc3485e7-dc7b-4a99-8527-82af98086fd8" />
<img width="147" height="66" alt="image" src="https://github.com/user-attachments/assets/34ada352-b993-4b21-aada-1d6f4f4f8fac" />
