### PR TITLE
fix: Show live indicator only when channel is live

### DIFF
--- a/src/components/LiveIndicator.astro
+++ b/src/components/LiveIndicator.astro
@@ -13,7 +13,7 @@ const { channelName } = Astro.props;
   rel="noopener noreferrer"
   title={`¡${channelName} está en directo! Haz clic para unirte.`}
   class="fixed bottom-6 right-6 z-50
-    inline-flex items-center gap-3
+    hidden items-center gap-3
     py-2 px-4
     bg-rose-600 text-white
     font-bold text-sm rounded-full
@@ -44,6 +44,7 @@ const { channelName } = Astro.props;
 
         if (data.isLive) {
           indicator.classList.remove("hidden");
+          indicator.classList.add("inline-flex");
         }
       } catch (error) {
         console.error("Error fetching Twitch live status:", error);


### PR DESCRIPTION
The live indicator is now hidden by default and only shown when the channel is detected to be live. This prevents the indicator from appearing unnecessarily on pages where the channel is not broadcasting.