### PR TITLE
⚙️Caution when installing very recent versions (3 days)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 4320


### PR DESCRIPTION
Given the recent attacks on package managers, it is good to have a time margin so that new versions of npm packages can be reviewed. This change means that `pnpm` will not install any version of some of these dependencies if at least **`3 days`** have not passed since their publication.

https://pnpm.io/settings#minimumreleaseage