### PR TITLE
feat: update Hero component content and layout adjustments

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -4,30 +4,38 @@ import Link from "./common/Link.astro";
 import Countdown from "./Countdown.astro";
 ---
 
-<header class="flex flex-col gap-6 items-center">
+<header class="flex flex-col gap-7 items-center">
   <div class="flex flex-col gap-3 items-center px-4">
     <hgroup class="flex flex-col items-center">
       <h1
         class="fade-in-up text-hero-title text-center font-semibold font-handlee leading-12"
         style="--stagger:0"
       >
-        AforShow 2025
+        ¡Gracias por estar presente en el {" "}
       </h1>
       <p class="text-hero-inner-title text-center font-semibold font-handlee">
         <span class="fade-in-up inline-block" style="--stagger:1">
-          ¡Comparte,
-        </span>
-        <span class="fade-in-up inline-block" style="--stagger:2">
-          aprende,
-        </span>
-        <span class="fade-in-up inline-block" style="--stagger:3">
-          inspira!
+          Aforshow!
         </span>
       </p>
     </hgroup>
   </div>
 
-  <Countdown class="fade-in-up" />
+  <!-- <Countdown class="fade-in-up" /> -->
+  <div class="md:w-3/6 w-full px-4">
+    <h2 class="text-caTextSecondary text-lg mb-3 text-center">
+      Puedes ver la repetición del evento aquí:
+    </h2>
+    <div class="aspect-video w-full h-full">
+      <iframe
+        src="https://player.twitch.tv/?video=2582273307&parent=afor.show"
+        frameborder="0"
+        allowfullscreen
+        scrolling="no"
+        height="100%"
+        width="100%"></iframe>
+    </div>
+  </div>
 
   <footer
     style="--stagger:4"
@@ -38,15 +46,14 @@ import Countdown from "./Countdown.astro";
       variant="secondary">Ver charlas pasadas</Link
     >
     <Link href="https://twitch.tv/afor_digital" variant="primary"
-      >¡Ver el evento!</Link
+      >¡Visita el canal!</Link
     >
   </footer>
-
   <section
-    class="flex xl:max-2xl:justify-start 2xl:justify-end w-full h-[350px] pointer-events-none overflow-x-hidden"
+    class="flex xl:max-2xl:justify-start 2xl:justify-end w-full h-[250px] pointer-events-none overflow-x-hidden"
   >
     <HeroSvg
-      class="-translate-x-10 shrink-0 h-[350px] xl:translate-x-0 ml-auto"
+      class="-translate-x-10 shrink-0 h-[250px] xl:translate-x-0 ml-auto"
     />
   </section>
 </header>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,7 @@ import Layout from "../layouts/Layout.astro";
   <Navbar />
   <Hero />
   <main
-    class="w-full max-w-4xl mx-auto text-cs-black min-h-screen gap-28 lg:mt-28 mb-6 flex flex-col items-center px-4"
+    class="w-full max-w-4xl mx-auto text-cs-black min-h-screen gap-32 lg:mt-20 mb-6 flex flex-col items-center px-4"
   >
     <ShareInfoSection />
     <Talks />


### PR DESCRIPTION
This pull request updates the homepage to reflect that the Aforshow 2025 event has concluded and now promotes the event replay instead of the live countdown. The main hero section messaging and layout have been adjusted, and the Twitch replay is now embedded directly on the page. Additionally, some spacing and sizing tweaks were made for improved presentation.

**Homepage content and messaging updates:**

* Changed the hero section headline to thank attendees and updated the subheading to "Aforshow!" instead of the previous call to action. The countdown timer has been commented out and replaced with an embedded Twitch video replay and a message inviting users to watch the event recording. (`src/components/Hero.astro`)
* Updated the primary action button text in the hero footer from "¡Ver el evento!" to "¡Visita el canal!" to reflect the event's conclusion. (`src/components/Hero.astro`)

**Layout and style adjustments:**

* Reduced the height of the hero SVG section from 350px to 250px for a more compact appearance. (`src/components/Hero.astro`)
* Increased the main content gap and adjusted top margin for better spacing on the homepage. (`src/pages/index.astro`)

<img width="1803" height="1286" alt="image" src="https://github.com/user-attachments/assets/3278d855-44a6-47a6-ba9f-b51b9b709bb2" />
